### PR TITLE
Improve norminette+ output

### DIFF
--- a/test/norminette.sh
+++ b/test/norminette.sh
@@ -5,6 +5,6 @@ if [ "$output" = "" ]
 then
     exit 0
 else
-    echo $output
+    echo "$output"
     exit 42
 fi


### PR DESCRIPTION
Now preserves newlines.

Before:
```
Norme: ./srcs/builtins/builtin_cd.c Error (line 103): multiple operations Error (line 122): multiple operations Error (line 329): multiple operations
```

After:
```
Norme: ./srcs/builtins/builtin_cd.c
Error (line 103): multiple operations
Error (line 122): multiple operations
Error (line 329): multiple operations
```