### PR TITLE
Fixes #67 where term_reset would send an error value that isn't caught by its parent function

### DIFF
--- a/srcs/term_settings/term_get_attributes.c
+++ b/srcs/term_settings/term_get_attributes.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/18 18:08:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/04/19 20:32:26 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/05/27 10:27:45 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,13 +20,13 @@ int		term_get_attributes(int fd, t_term *term_p)
 	if (term_p == NULL)
 		return (FUNCT_FAILURE);
 	ret = tcgetattr(fd, term_p->termios_p);
-	if (ret == FUNCT_ERROR)
+	if (ret == -1)
 	{
 		ft_eprintf("Couldn't get terminal attributes.\n");
 		return (FUNCT_FAILURE);
 	}
 	ret = tcgetattr(fd, term_p->old_termios_p);
-	if (ret == FUNCT_ERROR)
+	if (ret == -1)
 	{
 		ft_eprintf("Couldn't get terminal attributes.\n");
 		return (FUNCT_FAILURE);

--- a/srcs/term_settings/term_reset_attributes.c
+++ b/srcs/term_settings/term_reset_attributes.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/18 18:19:47 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/05/21 20:41:40 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/05/27 10:21:17 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,6 @@ int		term_reset(t_term *term_p)
 	/* Is TCSANOW flag correct? */
 	ret = tcsetattr(STDIN_FILENO, TCSANOW, term_p->old_termios_p);
 	if (ret == -1)
-		return (FUNCT_ERROR);
+		return (FUNCT_FAILURE);
 	return (FUNCT_SUCCESS);
 }

--- a/srcs/term_settings/term_set_attributes.c
+++ b/srcs/term_settings/term_set_attributes.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/18 18:11:05 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/04/18 19:15:18 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/05/27 10:27:17 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ int		term_set_attributes(t_term *term_p)
 	term_p->termios_p->c_cc[VTIME] = 0;
 	/* Is TCSANOW flag correct? */
 	ret = tcsetattr(STDIN_FILENO, TCSANOW, term_p->termios_p);
-	if (ret == FUNCT_ERROR)
+	if (ret == -1)
 	{
 		ft_eprintf("Couldn't set terminal attributes.\n");
 		return (FUNCT_FAILURE);


### PR DESCRIPTION
## Description:

Also got rid of some statements that would compare a function that we didn't build ourselves, with our own FUNCT_ERROR or FUNCT_FAILURE defines. It makes more sense to only use those on our own functions which were made with these define values in mind.

**Related issue (if applicable):** fixes #67 

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
