### PR TITLE
Fix builtin exit

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/05/28 18:51:52 by omulder       ########   odam.nl         */
+/*   Updated: 2019/05/28 19:08:51 by omulder       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -283,7 +283,7 @@ void			lexer_state_ionum(t_scanner *scanner);
 **----------------------------------bultins-------------------------------------
 */
 
-void			builtin_exit(char exitcode);
+void			builtin_exit(unsigned char exitcode);
 int				builtin_echo(char **args);
 char			builtin_echo_set_flags(char **args, int *arg_i);
 

--- a/srcs/builtins/builtin_exit.c
+++ b/srcs/builtins/builtin_exit.c
@@ -6,13 +6,13 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/11 20:15:24 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/05/28 18:50:53 by omulder       ########   odam.nl         */
+/*   Updated: 2019/05/28 19:08:56 by omulder       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "vsh.h"
 
-void	builtin_exit(char exitcode)
+void	builtin_exit(unsigned char exitcode)
 {
 	ft_printf("exit\n");
 	exit((int)exitcode);


### PR DESCRIPTION
## Description:

This PR does only 3 things:
- Changes exit message to `exit\n` (and uses printf for it instead of putchar)
- Removes some free functions that wasn't used anywhere
- Adds exitcode to prototype of builtin_exit, so that it can exit with a exitcode of choice.

**Related issue (if applicable):** fixes #61

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
