### PR TITLE
Remove ft_strarrdel, rename ft_freearray to ft_strarrdel

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -19,7 +19,7 @@ ft_putstrarr.c ft_putstrarri.c ft_strdel.c ft_strdup.c ft_strjoin.c \
 ft_strlen.c ft_strnew.c ft_strsub.c ft_strreplace.c ft_isdigit.c \
 ft_isspace.c ft_intlen.c ft_memcpy.c ft_putendl.c ft_putstr.c ft_putnbr.c \
 ft_strcpy.c ft_strcat.c ft_strstr.c ft_putchar.c ft_bzero.c ft_isblank.c \
-ft_strcmp.c ft_isprint.c ft_freestrarray.c ft_arraylen.c \
+ft_strcmp.c ft_isprint.c ft_strarrdel.c ft_arraylen.c \
 ft_strcdup.c ft_strncmp.c ft_strequ.c ft_strnequ.c ft_strncpy.c ft_memset.c \
 ft_putchar_fd.c ft_putstr_fd.c ft_putendl_fd.c ft_putnbr_fd.c ft_lstlen.c \
 ft_lsttoarray.c ft_lstnew.c ft_lstaddback.c ft_lstadd.c ft_strchr.c \

--- a/libft/ft_strarradd.c
+++ b/libft/ft_strarradd.c
@@ -45,7 +45,7 @@ int			ft_strarradd(char ***arr, const char *add)
 	new[i] = ft_strdup(add);
 	if (new[i] == NULL)
 	{
-		ft_freestrarray(&new);
+		ft_strarrdel(&new);
 		return (false);
 	}
 	free(*arr);

--- a/libft/ft_strarrdel.c
+++ b/libft/ft_strarrdel.c
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        ::::::::            */
-/*   ft_freestrarray.c                                  :+:    :+:            */
+/*   ft_strarrdel.c                                     :+:    :+:            */
 /*                                                     +:+                    */
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-void	ft_freestrarray(char ***array_p)
+void	ft_strarrdel(char ***array_p)
 {
 	int index;
 

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -57,7 +57,7 @@ char				*ft_strjoinfree(char *s1, char *s2, int i);
 int					ft_strcmp(const char *s1, const char *s2);
 int					ft_isprint(int c);
 char				*ft_strcdup(char *str, char c);
-void				ft_freestrarray(char ***array_p);
+void				ft_strarrdel(char ***array_p);
 int					ft_arraylen(char **array);
 int					ft_strncmp(const char *s1, const char *s2, size_t n);
 t_list				*ft_lstnew(void *content, size_t content_size);

--- a/srcs/exec/exec_cmd.c
+++ b/srcs/exec/exec_cmd.c
@@ -23,5 +23,5 @@ void		exec_cmd(char **args, t_envlst *envlst, int *exit_code)
 			*exit_code = EXIT_NOTFOUND;
 		}
 	}
-	ft_freestrarray(&args);
+	ft_strarrdel(&args);
 }

--- a/srcs/exec/exec_find_binary.c
+++ b/srcs/exec/exec_find_binary.c
@@ -60,6 +60,6 @@ char			*exec_find_binary(char *filename, t_envlst *envlst)
 		}
 		i++;
 	}
-	ft_freestrarray(&paths);
+	ft_strarrdel(&paths);
 	return (ret);
 }

--- a/srcs/exec/exec_start.c
+++ b/srcs/exec/exec_start.c
@@ -24,7 +24,7 @@ static char	**init_array(t_ast *ast)
 	args[0] = ft_strdup(ast->value);
 	if (args[0] == NULL)
 	{
-		ft_freestrarray(&args);
+		ft_strarrdel(&args);
 		return (NULL);
 	}
 	return (args);
@@ -37,13 +37,13 @@ static int	add_argument(char ***args, char *value)
 	temp = ft_strdup(value);
 	if (temp == NULL)
 	{
-		ft_freestrarray(args);
+		ft_strarrdel(args);
 		return (FUNCT_FAILURE);
 	}
 	if (ft_strarradd(args, temp) == FUNCT_FAILURE)
 	{
 		ft_strdel(&temp);
-		ft_freestrarray(args);
+		ft_strarrdel(args);
 		return (FUNCT_FAILURE);
 	}
 	ft_strdel(&temp);

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -234,19 +234,19 @@ Test(builtin_echo, basic, .init=redirect_all_stdout)
 	exit_code = INT_MIN;
 	builtin_echo(args, &exit_code);
 	cr_expect(exit_code == 0);
-	ft_freestrarray(&args);
+	ft_strarrdel(&args);
 
 	args = ft_strsplit("echo|-Eea|\n", '|');
 	exit_code = INT_MIN;
 	builtin_echo(args, &exit_code);
 	cr_expect(exit_code == 0);
-	ft_freestrarray(&args);
+	ft_strarrdel(&args);
 
 	args = ft_strsplit("echo|-nEe", '|');
 	exit_code = INT_MIN;
 	builtin_echo(args, &exit_code);
 	cr_expect(exit_code == 0);
-	ft_freestrarray(&args);
+	ft_strarrdel(&args);
 
 	args = ft_strsplit("echo|-E", '|');
 	exit_code = INT_MIN;


### PR DESCRIPTION
## Description:

This PR:
- Removes ft_strarrdel
- renames ft_freearray to ft_strarrdel
- Adds check for NULL to ft_strarrdel

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
