### PR TITLE
Adds `||` operator support

### DIFF
--- a/srcs/exec/exec_start.c
+++ b/srcs/exec/exec_start.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/05/29 17:52:22 by omulder        #+#    #+#                */
-/*   Updated: 2019/07/18 12:26:35 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/07/20 16:23:40 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -168,6 +168,8 @@ void		exec_start(t_ast *ast, t_envlst *envlst, int *exit_code, int flags)
 	
 	/* Runs after the above exec_start returns or isn't run */
 	if (ast->type == AND_IF && *exit_code != EXIT_SUCCESS)
+		return ;
+	else if (ast->type == OR_IF && *exit_code == EXIT_SUCCESS)
 		return ;
 	else if (ast->type == WORD || ast->type == ASSIGN || ast->type == SGREAT)
 		exec_complete_command(ast, envlst, exit_code, flags);


### PR DESCRIPTION
## Description:

Operator || functionality
Example: 
`echo hoi || echo doei`
Only echo's hoi

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
