### PR TITLE
leak fix for alias replace

### DIFF
--- a/srcs/alias/alias_replace.c
+++ b/srcs/alias/alias_replace.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/26 20:29:50 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/07/28 17:17:12 by omulder       ########   odam.nl         */
+/*   Updated: 2019/07/30 14:27:28 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ static void	alias_combine_tokenlsts(t_tokenlst *probe, t_tokenlst *new_tokenlst)
 		start_end = start_end->next;
 	ft_memdel((void**)&start_end->next);
 	start_end->next = probe->next->next;
+	ft_strdel(&probe->next->value);
 	ft_memdel((void**)&probe->next);
 	probe->next = new_tokenlst;
 }


### PR DESCRIPTION
## Description:

fixes leak because token_lst->value was not deleted

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
