### PR TITLE
fixes quoting and escape issues

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,13 +6,13 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/07/30 17:50:31 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/07/31 10:39:53 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef VSH_H
 # define VSH_H
-// # define DEBUG
+# define DEBUG
 # include <sys/stat.h>
 # include <fcntl.h>
 

--- a/srcs/lexer/lexer_state_strings.c
+++ b/srcs/lexer/lexer_state_strings.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/05/19 12:12:00 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/07/30 15:39:04 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/07/31 10:49:35 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,9 +35,9 @@ void	lexer_state_word(t_scanner *scanner)
 	if (CURRENT_CHAR == '=' &&
 		(scanner->flags & T_FLAG_HASSPECIAL) == false)
 		scanner->flags |= T_FLAG_HASEQUAL;
-	if (CURRENT_CHAR == '"')
+	if (CURRENT_CHAR == '"' && (scanner->flags & T_STATE_SQUOTE) == false)
 		scanner->flags ^= T_STATE_DQUOTE;
-	if (CURRENT_CHAR == '\'')
+	if (CURRENT_CHAR == '\'' && (scanner->flags & T_STATE_DQUOTE) == false)
 		scanner->flags ^= T_STATE_SQUOTE;
 	if (CURRENT_CHAR == '\\' && (scanner->flags & T_STATE_SQUOTE) == false)
 		lexer_change_state(scanner, &lexer_state_word_esc);


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

Fixes  "input '"' goes wrong in lexer or parser"

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
