### PR TITLE
Fix leaking binary path

### DIFF
--- a/srcs/exec/exec_external.c
+++ b/srcs/exec/exec_external.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/05/31 10:47:19 by tde-jong       #+#    #+#                */
-/*   Updated: 2019/08/01 11:39:42 by tde-jong      ########   odam.nl         */
+/*   Updated: 2019/08/01 11:43:31 by tde-jong      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,6 +80,7 @@ bool			exec_external(char **args, t_vshdata *vshdata)
 	{
 		ft_printf("vsh: failed to allocate enough memory!\n");
 		g_state->exit_code = EXIT_FAILURE;
+		ft_strdel(&binary);
 		return (false);
 	}
 	return (exec_bin(binary, args, vshenviron));


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
