### PR TITLE
fix invalid assign bug

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/08/02 15:45:26 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/08/04 13:01:03 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,7 +94,7 @@
 # define T_FLAG_HASSPECIAL (1 << 0)
 # define T_STATE_SQUOTE (1 << 1)
 # define T_STATE_DQUOTE (1 << 2)
-# define T_FLAG_HASEQUAL (1 << 3)
+# define T_FLAG_ISASSIGN (1 << 3)
 # define T_MALLOC_ERROR (1 << 4)
 
 /*

--- a/srcs/lexer/lexer_state_strings.c
+++ b/srcs/lexer/lexer_state_strings.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/05/19 12:12:00 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/07/31 10:49:35 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/08/04 12:59:56 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,9 +32,9 @@ void	lexer_state_word(t_scanner *scanner)
 {
 	if (tool_is_special(CURRENT_CHAR) == true)
 		scanner->flags |= T_FLAG_HASSPECIAL;
-	if (CURRENT_CHAR == '=' &&
-		(scanner->flags & T_FLAG_HASSPECIAL) == false)
-		scanner->flags |= T_FLAG_HASEQUAL;
+	if (CURRENT_CHAR == '=' && scanner->str[0] != '='
+		&& (scanner->flags & T_FLAG_HASSPECIAL) == false)
+		scanner->flags |= T_FLAG_ISASSIGN;
 	if (CURRENT_CHAR == '"' && (scanner->flags & T_STATE_SQUOTE) == false)
 		scanner->flags ^= T_STATE_DQUOTE;
 	if (CURRENT_CHAR == '\'' && (scanner->flags & T_STATE_DQUOTE) == false)
@@ -47,7 +47,7 @@ void	lexer_state_word(t_scanner *scanner)
 	else if ((scanner->flags & T_STATE_DQUOTE ||
 			scanner->flags & T_STATE_SQUOTE) && CURRENT_CHAR != '\0')
 		lexer_change_state(scanner, &lexer_state_word);
-	else if (scanner->flags & T_FLAG_HASEQUAL)
+	else if (scanner->flags & T_FLAG_ISASSIGN)
 		scanner->tk_type = ASSIGN;
 	else
 		scanner->tk_type = WORD;


### PR DESCRIPTION
## Description:

Any word starting with an equal sign is not a valid assign anymore

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
