### PR TITLE
Bug fix for tmp env vars that already exist

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/08/13 15:01:14 by tde-jong      ########   odam.nl         */
+/*   Updated: 2019/08/17 16:32:12 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -132,6 +132,7 @@
 
 
 # define ENV_MASK 0xF8
+# define ENV_TMP_OVERWRITE (1 << 4)
 # define ENV_SPECIAL (1 << 3)
 # define ENV_EXTERN (1 << 2)
 # define ENV_LOCAL (1 << 1)

--- a/srcs/builtins/builtin_assign.c
+++ b/srcs/builtins/builtin_assign.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/06/05 09:09:49 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/08/03 10:52:32 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/08/17 16:32:00 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,11 @@ int			builtin_assign_addexist(t_envlst *envlst, char *var, int env_type)
 		if (ft_strnequ(var, probe->var, varlen) == true &&
 		probe->var[varlen] == '=')
 		{
+			if (env_type & ENV_TEMP)
+			{
+				probe->type |= ENV_TMP_OVERWRITE;
+				return (FUNCT_FAILURE);
+			}
 			ft_strdel(&probe->var);
 			probe->type = env_type;
 			probe->var = var;

--- a/srcs/environment_handling/env_lsttoarr.c
+++ b/srcs/environment_handling/env_lsttoarr.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/06/04 10:54:56 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/08/06 11:05:07 by tde-jong      ########   odam.nl         */
+/*   Updated: 2019/08/17 16:42:37 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,8 @@ int		env_lstlen(t_envlst *lst)
 	len = 0;
 	while (probe != NULL)
 	{
-		if (probe->type & (ENV_EXTERN | ENV_TEMP))
+		if (probe->type & (ENV_EXTERN | ENV_TEMP) &&
+			(probe->type & ENV_TMP_OVERWRITE) == false)
 			len++;
 		probe = probe->next;
 	}
@@ -43,7 +44,8 @@ char	**env_lsttoarr(t_envlst *lst)
 	probe = lst;
 	while (i < len)
 	{
-		if (probe->type & (ENV_EXTERN | ENV_TEMP))
+		if (probe->type & (ENV_EXTERN | ENV_TEMP) &&
+			(probe->type & ENV_TMP_OVERWRITE) == false)
 		{
 			vshenviron[i] = probe->var;
 			i++;

--- a/srcs/environment_handling/env_remove_tmp.c
+++ b/srcs/environment_handling/env_remove_tmp.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/18 12:14:39 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/07/20 18:45:13 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/08/17 16:39:22 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,8 @@ void		env_remove_tmp(t_envlst *env)
 
 	if (env == NULL || env->next == NULL)
 		return ;
+	if (env->next->type & ENV_TMP_OVERWRITE)
+		env->next->type &= ~ENV_TMP_OVERWRITE;
 	if (env->next->type == ENV_TEMP)
 	{
 		tmp = env->next;


### PR DESCRIPTION
## Description:

Fixes bug where tmp env vars already exist in env lst

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
