### PR TITLE
[21sh] if input_read fails, this commit will make sure that FUNCT_ERROR is returned instead of FUNCT_SUCCESS

### DIFF
--- a/srcs/shell/shell_dless_input.c
+++ b/srcs/shell/shell_dless_input.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/06/02 13:23:16 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/09/09 14:46:15 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/09/16 07:35:21 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 


### PR DESCRIPTION
## Description:

 if input_read fails, this commit will make sure that FUNCT_ERROR is returned instead of FUNCT_SUCCESS

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
