### PR TITLE
Leak in get_curs_row has been fixed.

### DIFF
--- a/srcs/input_handling/input_print_str.c
+++ b/srcs/input_handling/input_print_str.c
@@ -6,7 +6,7 @@
 /*   By: rkuijper <rkuijper@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/23 11:54:27 by rkuijper       #+#    #+#                */
-/*   Updated: 2019/09/12 17:42:41 by anonymous     ########   odam.nl         */
+/*   Updated: 2019/09/12 17:44:10 by rkuijper      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [X] The code change works
  - [X] Passes all tests: `make test`
  - [X] There is no commented out code in this PR.
  - [X] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [X] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
