### PR TITLE
leak fix in shell init term

### DIFF
--- a/srcs/shell/shell_init_vshdata.c
+++ b/srcs/shell/shell_init_vshdata.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/29 12:42:44 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/09/16 18:18:07 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/09/19 16:17:30 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,8 @@ static int	shell_init_data(t_vshdata *data)
 
 int 		shell_init_term(t_vshdata *data)
 {
+	free(data->term->old_termios_p);
+	free(data->term->termios_p);
 	free(data->term);
 	data->term = term_prepare(data->envlst);
 	data->termcaps = shell_init_vshdatatermcaps();


### PR DESCRIPTION
## Description:

small leak fix

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
