### PR TITLE
Fix get_next_line issue so BUFF_SIZE can be higher

### DIFF
--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,18 +6,14 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/01/09 11:10:09 by omulder        #+#    #+#                */
-/*   Updated: 2019/08/29 14:56:38 by omulder       ########   odam.nl         */
+/*   Updated: 2019/09/19 19:37:48 by omulder       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef LIBFT_H
 # define LIBFT_H
 
-/*
-**	MUCH PROBLEM IF YOU CHANGE BUFFSIZE TO > 1
-*/
-
-# define BUFF_SIZE 1
+# define BUFF_SIZE 1024
 # include "ft_printf.h"
 # include <stdbool.h>
 

--- a/srcs/history/history_get_file_content.c
+++ b/srcs/history/history_get_file_content.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/05/30 13:49:22 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/08/06 11:09:15 by tde-jong      ########   odam.nl         */
+/*   Updated: 2019/09/19 19:37:06 by omulder       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,6 +49,20 @@ static int		allocate_leftover_history(t_vshdata *data, int i)
 	return (FUNCT_SUCCESS);
 }
 
+static void		empty_gnl(int fd)
+{
+	int		ret;
+	char	*line;
+
+	line = NULL;
+	ret = ft_get_next_line_delim(fd, &line, HIST_SEPARATE);
+	while (ret != 0 && ret != -1)
+	{
+		ft_strdel(&line);
+		ret = ft_get_next_line_delim(fd, &line, HIST_SEPARATE);
+	}
+}
+
 int				history_get_file_content(t_vshdata *data)
 {
 	int		fd;
@@ -71,9 +85,8 @@ int				history_get_file_content(t_vshdata *data)
 			return (FUNCT_ERROR);
 		i++;
 	}
+	empty_gnl(fd);
 	close(fd);
 	ret = allocate_leftover_history(data, i);
-	if (ret == FUNCT_ERROR)
-		return (FUNCT_ERROR);
-	return (FUNCT_SUCCESS);
+	return (ret);
 }


### PR DESCRIPTION
## Description:

This PR fixes the issue where history might not read the whole file (although since supporting multiline commands this should only happen when you change HIST_MAX to a lower number..) and leaves some bullshit in gnl's buffer. This causes problems when alias uses it to read the alias file that might exist, using the same fd. So how do we solve this? We make sure to read the whole file when history does it's file reading.

I set the GNL buffer to 1024 but feel free to discus this.

**Related issue (if applicable):** fixes #266 

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
