### PR TITLE
Doubles len_max to minimize mallocs

### DIFF
--- a/srcs/input_handling/input_clear_char_at.c
+++ b/srcs/input_handling/input_clear_char_at.c
@@ -30,8 +30,8 @@ int			input_add_chunk(t_vshdata *data, char *chunk, int chunk_len,
 {
 	char *tmp;
 
-	if (data->line->len_cur + chunk_len > data->line->len_max)
-		data->line->len_max += chunk_len;
+	while (data->line->len_cur + chunk_len > data->line->len_max)
+		data->line->len_max *= 2;
 	tmp = ft_strnew(data->line->len_max);
 	if (tmp == NULL)
 		return (FUNCT_ERROR);


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
