### PR TITLE
Fix builtin assign with empty var

### DIFF
--- a/srcs/builtins/builtin_assign.c
+++ b/srcs/builtins/builtin_assign.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/06/05 09:09:49 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/10/01 16:08:51 by tde-jong      ########   odam.nl         */
+/*   Updated: 2019/10/01 16:34:58 by tde-jong      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ int			builtin_assign_addexist(t_envlst *envlst, char *var, int env_type)
 
 	probe = envlst;
 	varlen = ft_strclen(var, '=');
-	if (ft_strchr(var, '=') == NULL)
+	if (var[varlen] == '\0')
 		return (FUNCT_FAILURE);
 	while (probe != NULL)
 	{


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
