### PR TITLE
Fix autocomplete error message

### DIFF
--- a/srcs/autocomplete/auto_get_cmdlst.c
+++ b/srcs/autocomplete/auto_get_cmdlst.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/10 12:53:34 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/10/07 11:40:27 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/10/08 10:52:04 by tde-jong      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,10 +37,7 @@ static int	file_exec_check(char *path, char *filename)
 		return (err_ret(E_ALLOC_STR));
 	file_status = ft_is_regular_file(bin_path);
 	if (file_status == -1)
-	{
-		ft_strdel(&bin_path);
-		return (err_ret_exit(E_STAT_STR, EXIT_FAILURE));
-	}
+		file_status = false;
 	ret = FUNCT_SUCCESS;
 	if (file_status == false)
 		ret = FUNCT_FAILURE;


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->
This fixes an error message that it couldn't stat a file if there are no permissions to follow a symlink. I'm pretty sure we don't want to include these entries in autocomplete anyway.

**Related issue (if applicable):** fixes #313 

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
