### PR TITLE
fixes lines not being added to history when they look the same

### DIFF
--- a/srcs/history/history_line_to_array.c
+++ b/srcs/history/history_line_to_array.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/05/30 18:55:25 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/09/22 12:16:17 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/10/10 14:49:52 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,8 @@ static int	is_same_cmd(t_history **history, char *line, int index, int line_len)
 		return (false);
 	if (line[line_len - 1] == '\n')
 		line_len--;
-	if (ft_strnequ(history[prev]->str, line, line_len) == true)
+	if (ft_strnequ(history[prev]->str, line, line_len) == true &&
+		history[prev]->str[line_len] == '\0')
 		return (true);
 	return (false);
 }


### PR DESCRIPTION
## Description:

fixes lines not being added to history when they look the same because of strnequ

fixes #337 

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
