### PR TITLE
Dollar expan quote bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: omulder <omulder@student.codam.nl>           +#+                      #
 #                                                    +#+                       #
 #    Created: 2019/04/10 20:30:07 by jbrinksm       #+#    #+#                 #
-#    Updated: 2019/10/07 12:20:18 by jbrinksm      ########   odam.nl          #
+#    Updated: 2019/10/11 16:32:33 by mavan-he      ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 
@@ -48,7 +48,7 @@ tools_is_char_escaped tool_is_redirect_tk tools_is_valid_identifier \
 tools_is_builtin tool_is_special tool_check_for_special tools_is_fdnumstr \
 tools_isidentifierchar tool_check_for_whitespace tool_get_paths \
 tools_isprintnotblank tools_get_pid_state tools_contains_quoted_chars \
-tools_is_cmd_seperator \
+tools_is_cmd_seperator tools_remove_quotes_etc \
 builtin_echo builtin_echo_set_flags builtin_exit builtin_assign \
 builtin_export builtin_export_print builtin_set builtin_unset \
 builtin_alias builtin_alias_set builtin_alias_lstdel builtin_unalias \

--- a/srcs/exec/exec_quote_remove.c
+++ b/srcs/exec/exec_quote_remove.c
@@ -6,105 +6,11 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/13 11:20:18 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/10/11 15:55:09 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/10/11 16:31:02 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "vsh.h"
-
-static void	remove_backslash(char *str, int *i, int *i_new)
-{
-	(*i)++;
-	str[*i_new] = str[*i];
-	(*i)++;
-	(*i_new)++;
-}
-
-/*
-**	In a expandable heredoc we only want to escape '\', '$', and
-**	handle the special line continuation (escaped '\n').
-*/
-
-static void	remove_heredoc_backslash(char *str, int *i, int *i_new)
-{
-	(*i)++;
-	if (str[*i] == '\\' || str[*i] == '$')
-	{
-		str[*i_new] = str[*i];
-		(*i_new)++;
-		(*i)++;
-	}
-	else if (str[*i] == '\n')
-		(*i)++;
-	else
-		(*i)--;
-}
-
-static void	remove_double_quote(char *str, int *i, int *i_new)
-{
-	(*i)++;
-	while (str[*i] != '"' && str[*i] != '\0')
-	{
-		if (str[*i] == '\\' && ft_strchr("\"\\$", str[(*i) + 1]))
-			remove_backslash(str, i, i_new);
-		else
-		{
-			str[*i_new] = str[*i];
-			(*i_new)++;
-			(*i)++;
-		}
-	}
-	if (str[*i] == '"')
-		(*i)++;
-}
-
-static void	remove_single_quote(char *str, int *i, int *i_new)
-{
-	(*i)++;
-	while (str[*i] != '\'' && str[*i] != '\0')
-	{
-		str[*i_new] = str[*i];
-		(*i_new)++;
-		(*i)++;
-	}
-	if (str[*i] == '\'')
-		(*i)++;
-}
-
-/*
-**	Iterates through the whole string and removes any quoting characters that
-**	are still present. If the string is a heredoc, limited measures will be
-**	taken.
-*/
-
-void	tools_remove_quotes_etc(char *str, bool is_heredoc)
-{
-	int		i;
-	int		i_new;
-
-	i = 0;
-	i_new = 0;
-	if (str == NULL)
-		return ;
-	while (str[i] != '\0')
-	{
-		if (str[i] == '\\' && is_heredoc == false)
-			remove_backslash(str, &i, &i_new);
-		else if (str[i] == '\\' && is_heredoc == true)
-			remove_heredoc_backslash(str, &i, &i_new);
-		else if (str[i] == '\'' && is_heredoc == false)
-			remove_single_quote(str, &i, &i_new);
-		else if (str[i] == '"' && is_heredoc == false)
-			remove_double_quote(str, &i, &i_new);
-		else
-		{
-			str[i_new] = str[i];
-			i++;
-			i_new++;
-		}
-	}
-	ft_bzero(&str[i_new], i - i_new);
-}
 
 /*
 **	Performs quote removal on all the WORD and ASSIGN tokens from the

--- a/srcs/tools/tools_remove_quotes_etc.c
+++ b/srcs/tools/tools_remove_quotes_etc.c
@@ -1,0 +1,109 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   tools_remove_quotes_etc.c                          :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2019/10/11 16:31:09 by mavan-he       #+#    #+#                */
+/*   Updated: 2019/10/11 16:31:44 by mavan-he      ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "vsh.h"
+
+static void	remove_backslash(char *str, int *i, int *i_new)
+{
+	(*i)++;
+	if (str[(*i)] == '\0')
+		return ;
+	str[*i_new] = str[*i];
+	(*i)++;
+	(*i_new)++;
+}
+
+/*
+**	In a expandable heredoc we only want to escape '\', '$', and
+**	handle the special line continuation (escaped '\n').
+*/
+
+static void	remove_heredoc_backslash(char *str, int *i, int *i_new)
+{
+	(*i)++;
+	if (str[*i] == '\\' || str[*i] == '$')
+	{
+		str[*i_new] = str[*i];
+		(*i_new)++;
+		(*i)++;
+	}
+	else if (str[*i] == '\n')
+		(*i)++;
+	else
+		(*i)--;
+}
+
+static void	remove_double_quote(char *str, int *i, int *i_new)
+{
+	(*i)++;
+	while (str[*i] != '"' && str[*i] != '\0')
+	{
+		if (str[*i] == '\\' && ft_strchr("\"\\$", str[(*i) + 1]) != NULL)
+			remove_backslash(str, i, i_new);
+		else
+		{
+			str[*i_new] = str[*i];
+			(*i_new)++;
+			(*i)++;
+		}
+	}
+	if (str[*i] == '"')
+		(*i)++;
+}
+
+static void	remove_single_quote(char *str, int *i, int *i_new)
+{
+	(*i)++;
+	while (str[*i] != '\'' && str[*i] != '\0')
+	{
+		str[*i_new] = str[*i];
+		(*i_new)++;
+		(*i)++;
+	}
+	if (str[*i] == '\'')
+		(*i)++;
+}
+
+/*
+**	Iterates through the whole string and removes any quoting characters that
+**	are still present. If the string is a heredoc, limited measures will be
+**	taken.
+*/
+
+void	tools_remove_quotes_etc(char *str, bool is_heredoc)
+{
+	int		i;
+	int		i_new;
+
+	i = 0;
+	i_new = 0;
+	if (str == NULL)
+		return ;
+	while (str[i] != '\0')
+	{
+		if (str[i] == '\\' && is_heredoc == false)
+			remove_backslash(str, &i, &i_new);
+		else if (str[i] == '\\' && is_heredoc == true)
+			remove_heredoc_backslash(str, &i, &i_new);
+		else if (str[i] == '\'' && is_heredoc == false)
+			remove_single_quote(str, &i, &i_new);
+		else if (str[i] == '"' && is_heredoc == false)
+			remove_double_quote(str, &i, &i_new);
+		else
+		{
+			str[i_new] = str[i];
+			i++;
+			i_new++;
+		}
+	}
+	ft_bzero(&str[i_new], i - i_new);
+}


### PR DESCRIPTION
## Description:

In quote removal:
Fixes invalid read when there is a quote without an ending quote in WORD
Fixes invalid read when there is a slash at the end of a WORD

Does not fix printing a single slash or quote in a word when it is a variable expansion (we probably won't handle this case)

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
