### PR TITLE
Clear hashtable when unsetting PATH

### DIFF
--- a/srcs/builtins/builtin_unset.c
+++ b/srcs/builtins/builtin_unset.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/19 18:45:24 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/08/22 11:55:30 by omulder       ########   odam.nl         */
+/*   Updated: 2019/10/14 13:20:07 by tde-jong      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,8 @@ void		builtin_unset(char **args, t_envlst *envlst)
 	g_state->exit_code = EXIT_SUCCESS;
 	while (args != NULL && *args != NULL)
 	{
+		if (ft_strequ(*args, "PATH") == true)
+			hash_reset(g_data);
 		if (tools_is_valid_identifier(*args) == false)
 		{
 			ft_eprintf(E_N_P_NOT_VAL_ID, "unset", *args);


### PR DESCRIPTION
## Description:

This clears the hashtable when one of the arguments of builtin `unset` is equal tot `PATH`
<!-- PR description goes here -->

**Related issue (if applicable):** fixes #344

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
