### PR TITLE
Fix history skipping the most recent item sometimes

### DIFF
--- a/srcs/history/history_index_change.c
+++ b/srcs/history/history_index_change.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/31 15:58:58 by omulder        #+#    #+#                */
-/*   Updated: 2019/10/15 13:55:33 by omulder       ########   odam.nl         */
+/*   Updated: 2019/10/22 10:54:54 by tde-jong      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,10 @@ int			history_index_change_down(t_datahistory *history)
 	if (history->current == NULL)
 		return (FUNCT_FAILURE);
 	if (history->current->next == NULL)
+	{
+		history->current = NULL;
 		return (FUNCT_FAILURE);
+	}
 	history->current = history->current->next;
 	return (FUNCT_SUCCESS);
 }


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->
The current pointer was not being set correctly in 1 case. This is now fixed.

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
