### PR TITLE
Tilde expan handles user paths

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/10/22 11:46:46 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/10/23 17:40:17 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,7 @@
 # define E_BINARY_FILE		SHELL ": cannot execute binary file\n"
 # define E_HIST_NOT_FOUND   SHELL ": !%s: event not found\n"
 # define E_HIST_NUM_ERROR   SHELL ": %.*s: event not found\n"
+# define E_INVALID_USER		SHELL ": could not get working directory of: %s\n"
 # define E_ALLOC 42
 # define E_DUP 100
 # define E_OPEN 101

--- a/srcs/expan/expan_handle_variables.c
+++ b/srcs/expan/expan_handle_variables.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/07/07 20:54:47 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/08/06 12:20:34 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/10/23 18:40:25 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,22 +36,23 @@ static int	scan_value(t_ast *node, t_envlst *envlst)
 {
 	char	quote;
 	int		i;
-	char	**value;
 
-	value = &node->value;
 	i = 0;
 	quote = '\0';
-	if (expan_tilde_expansion(node, &i) == FUNCT_ERROR)
-		return (FUNCT_ERROR);
-	while ((*value)[i] != '\0')
+	while (node->value[i] != '\0')
 	{
-		if ((*value)[i] == '\\' && quote != '\'')
+		if (node->value[i] == '\\' && quote != '\'')
 			i += 2;
-		else if ((*value)[i] == '\'' || (*value)[i] == '\"')
-			update_quote_status((*value)[i], &i, &quote);
-		else if ((*value)[i] == '$' && quote != '\'')
+		else if (node->value[i] == '\'' || node->value[i] == '\"')
+			update_quote_status(node->value[i], &i, &quote);
+		else if (node->value[i] == '$' && quote != '\'')
 		{
-			if (expan_handle_dollar(value, &i, envlst) == FUNCT_ERROR)
+			if (expan_handle_dollar(&node->value, &i, envlst) == FUNCT_ERROR)
+				return (FUNCT_ERROR);
+		}
+		else if (node->value[i] == '~')
+		{
+			if (expan_tilde_expansion(node, &i) == FUNCT_ERROR)
 				return (FUNCT_ERROR);
 		}
 		else


### PR DESCRIPTION
## Description:

Tilde expansion now handles ~mavan-he/
If the user does not exist it will return an error and the cmd is not executed
Also an assign with paths separated by a colon will work now```dit=~jbrinksm:~rkuijper```

**Related issue (if applicable):** fixes #302

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
