### PR TITLE
Fixed issue with no exit state in builtin_jobs.

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/10/31 09:40:17 by rkuijper      ########   odam.nl         */
+/*   Updated: 2019/10/31 11:47:40 by rkuijper      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -983,7 +983,7 @@ void			builtin_unalias(char **args, t_aliaslst **aliaslst);
 void			builtin_type(char **args, t_envlst *envlst,
 				t_aliaslst *aliaslst);
 
-int				builtin_jobs(char **args, t_vshdata *data);
+void			builtin_jobs(char **args, t_vshdata *data);
 t_job			*builtin_jobs_find_job(char *job_id, t_job *joblist);
 int				builtin_jobs_new_current_val(t_job *joblist);
 

--- a/srcs/builtins/builtin_bg.c
+++ b/srcs/builtins/builtin_bg.c
@@ -6,7 +6,7 @@
 /*   By: rkuijper <rkuijper@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/10/30 16:22:05 by rkuijper       #+#    #+#                */
-/*   Updated: 2019/10/30 17:16:25 by rkuijper      ########   odam.nl         */
+/*   Updated: 2019/10/31 11:45:51 by rkuijper      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,10 @@ void			builtin_bg(char **av, t_vshdata *data)
 		jobs_continue_job(job, false);
 	else
 	{
-		ft_eprintf(E_BG_JOB_RUN, av[1] == NULL ? "1" : av[1]);
+		if (av[1] == NULL)
+			ft_eprintf(E_BG_JOB_RUN, "1");
+		else
+			ft_eprintf(E_BG_JOB_RUN, av[1]);
 		return ;
 	}
 	g_state->exit_code = EXIT_SUCCESS;

--- a/srcs/builtins/builtin_jobs.c
+++ b/srcs/builtins/builtin_jobs.c
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/17 14:03:16 by rkuijper       #+#    #+#                */
-/*   Updated: 2019/10/30 21:43:09 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/10/31 11:51:27 by rkuijper      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,19 +87,23 @@ static void		jobs_log_all(t_datajobs *jobs, int options)
 	}
 }
 
-int				builtin_jobs(char **args, t_vshdata *data)
+void			builtin_jobs(char **args, t_vshdata *data)
 {
 	int	arg;
 	int options;
 
 	arg = 1;
 	options = JOB_OPT_NONE;
+	g_state->exit_code = EXIT_FAILURE;
 	if (read_options(args, &arg, &options) != FUNCT_SUCCESS)
-		return (FUNCT_ERROR);
+		return ;
 	jobs_handle_finished_jobs();
 	if (args[arg] != NULL)
-		jobs_log_args(data->jobs, options, args + arg);
+	{
+		if (jobs_log_args(data->jobs, options, args + arg) == FUNCT_ERROR)
+			return ;
+	}
 	else
 		jobs_log_all(data->jobs, options);
-	return (FUNCT_SUCCESS);
+	g_state->exit_code = EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [X] The code change works
  - [X] Passes all tests: `make test`
  - [X] There is no commented out code in this PR.
  - [X] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [X] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
