### PR TITLE
Fix redirection bug #372

### DIFF
--- a/srcs/jobs/jobs_exec_builtin.c
+++ b/srcs/jobs/jobs_exec_builtin.c
@@ -6,7 +6,7 @@
 /*   By: rkuijper <rkuijper@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/10/30 16:42:54 by rkuijper       #+#    #+#                */
-/*   Updated: 2019/10/31 13:27:13 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/10/31 16:11:54 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,7 @@ void		jobs_exec_builtin(t_proc *proc)
 	if (exec_create_files(proc->redir_and_assign) == FUNCT_ERROR ||
 		exec_assigns(proc->redir_and_assign, g_data, ENV_TEMP) == FUNCT_ERROR)
 		return ;
-	if (redir(proc->redir_and_assign) == FUNCT_ERROR)
+	if (exec_redirs(proc->redir_and_assign) == FUNCT_ERROR)
 	{
 		g_state->exit_code = EXIT_FAILURE;
 		return ;


### PR DESCRIPTION
## Description:

The wrong function was called on builtin redirections

**Related issue (if applicable):** fixes #372 

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
