### PR TITLE
env_getvalue instead of getenv

### DIFF
--- a/includes/vsh.h
+++ b/includes/vsh.h
@@ -6,7 +6,7 @@
 /*   By: omulder <omulder@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/04/10 20:29:42 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/11/02 15:19:37 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/04 10:20:40 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,6 @@
 # define E_N_P_NUM_REQ		SHELL ": %s: %s: numeric argument required\n"
 # define E_N_TOO_MANY		SHELL ": %s: too many arguments\n"
 # define E_N_P_NOT_VAL_ID	SHELL ": %s: '%s': not a valid identifier\n"
-# define E_N_FAIL_HOME		SHELL ": %s: failed to get home directory\n"
 # define E_NOT_CUR_DIR		SHELL ": cannot get current working directory\n"
 # define E_NOT_RESET		SHELL ": could not reset terminal settings\n"
 # define E_STAT_STR			SHELL ": could not get stat info of file\n"

--- a/srcs/autocomplete/auto_get_filelst.c
+++ b/srcs/autocomplete/auto_get_filelst.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/11 12:28:38 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/09/05 15:18:11 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/04 10:32:49 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,12 +33,12 @@ static int	auto_tilde_expan(char **path)
 {
 	char *home;
 
-	home = getenv("HOME");
+	home = env_getvalue("HOME", g_data->envlst);
 	if (home == NULL)
-		return (err_ret(E_N_FAIL_HOME));
+		return (err_ret("\n" E_HOME_NOTSET_STR));
 	home = ft_strjoin(home, *path + 1);
 	if (home == NULL)
-		return (err_ret(E_ALLOC_STR));
+		return (err_ret("\n" E_ALLOC_STR));
 	ft_strdel(path);
 	*path = home;
 	return (FUNCT_SUCCESS);

--- a/srcs/expan/expan_tilde_expansion.c
+++ b/srcs/expan/expan_tilde_expansion.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/02 13:50:51 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/10/23 18:42:25 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/04 10:34:57 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,9 @@ static int	expan_get_home_path(char *login, char **home_path)
 
 	if (login[0] == '\0')
 	{
-		*home_path = getenv("HOME");
-		if (home_path == NULL)
-			return (err_ret_prog_exit(E_N_FAIL_HOME, "tilde", EXIT_FAILURE));
+		*home_path = env_getvalue("HOME", g_data->envlst);
+		if (*home_path == NULL)
+			return (err_ret_exit(E_HOME_NOTSET_STR, EXIT_FAILURE));
 	}
 	else
 	{


### PR DESCRIPTION
## Description:

tilde expan error fix

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
