### PR TITLE
make shell work as dumb shell

### DIFF
--- a/srcs/shell/shell_init_input.c
+++ b/srcs/shell/shell_init_input.c
@@ -75,17 +75,6 @@ t_datatermcaps	*shell_init_vshdatatermcaps(void)
 	if (termcaps == NULL)
 		return (NULL);
 	termcaps->tc_clear_lines_str = tgetstr("cd", NULL);
-	if (termcaps->tc_clear_lines_str == NULL)
-	{
-		ft_memdel((void**)&termcaps);
-		return (NULL);
-	}
 	termcaps->tc_scroll_down_str = tgetstr("sf", NULL);
-	if (termcaps->tc_scroll_down_str == NULL)
-	{
-		ft_strdel(&termcaps->tc_clear_lines_str);
-		ft_memdel((void**)&termcaps);
-		return (NULL);
-	}
 	return (termcaps);
 }

--- a/srcs/term_settings/term_is_valid.c
+++ b/srcs/term_settings/term_is_valid.c
@@ -25,11 +25,9 @@ int		term_is_valid(t_envlst *envlst)
 
 	term_type = env_getvalue("TERM", envlst);
 	if (term_type == NULL)
-	{
-		ft_eprintf(E_TERM_NOT_SET);
-		return (FUNCT_FAILURE);
-	}
-	ret = tgetent(NULL, term_type);
+		ret = tgetent(NULL, "dumb");
+	else
+		ret = tgetent(NULL, term_type);
 	if (ret == -1)
 		ft_eprintf(E_TERM_DB_NOT_F);
 	if (ret == 0)


### PR DESCRIPTION
## Description:

<!-- PR description goes here -->

**Related issue (if applicable):** fixes #401<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
