### PR TITLE
Fix fifo writing through the magic of O_NONBLOCK

### DIFF
--- a/srcs/exec/exec_create_files.c
+++ b/srcs/exec/exec_create_files.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/06 16:16:21 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/10/30 17:49:15 by jbrinksm      ########   odam.nl         */
+/*   Updated: 2019/11/05 15:30:46 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ static int	check_if_valid_file(char *file)
 {
 	int		fd;
 
-	fd = open(file, O_RDONLY | O_CREAT, REG_PERM);
+	fd = open(file, O_RDONLY | O_CREAT | O_NONBLOCK, REG_PERM);
 	if (fd == -1)
 	{
 		if (fd == -1)

--- a/srcs/exec/exec_create_files.c
+++ b/srcs/exec/exec_create_files.c
@@ -35,8 +35,7 @@ static int	check_if_valid_file(char *file)
 	fd = open(file, O_RDONLY | O_CREAT | O_NONBLOCK, REG_PERM);
 	if (fd == -1)
 	{
-		if (fd == -1)
-			ft_eprintf(E_FAIL_OPEN_P, file);
+		ft_eprintf(E_FAIL_OPEN_P, file);
 		g_state->exit_code = EXIT_FAILURE;
 		return (FUNCT_ERROR);
 	}


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #395 
## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
