### PR TITLE
added slash to invalid name chars

### DIFF
--- a/srcs/autocomplete/auto_find_matches.c
+++ b/srcs/autocomplete/auto_find_matches.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/12 20:20:16 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/11/02 16:09:59 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/05 15:44:50 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,8 +44,7 @@ int			auto_find_filelst(char **match, t_list **matchlst)
 	i = match_len - 1;
 	while (i >= 0)
 	{
-		if (tools_is_valid_name_char((*match)[i]) == false || (*match)[i]
-			== '/')
+		if (tools_is_valid_name_char((*match)[i]) == false)
 			break ;
 		i--;
 	}

--- a/srcs/autocomplete/auto_find_state.c
+++ b/srcs/autocomplete/auto_find_state.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/12 17:12:17 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/11/02 16:12:31 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/05 15:45:03 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,7 @@ int			auto_find_state(char *line, ssize_t i)
 	i--;
 	while (i >= 0)
 	{
-		if (tools_is_valid_name_char(line[i]) == false || line[i] == '$' ||
-			line[i] == '/')
+		if (tools_is_valid_name_char(line[i]) == false || line[i] == '$')
 			break ;
 		i--;
 	}

--- a/srcs/autocomplete/auto_start.c
+++ b/srcs/autocomplete/auto_start.c
@@ -6,7 +6,7 @@
 /*   By: mavan-he <mavan-he@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/08/12 14:09:10 by mavan-he       #+#    #+#                */
-/*   Updated: 2019/11/02 15:37:41 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/05 15:45:27 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ char	*auto_get_file_str(char *line, ssize_t i)
 	i--;
 	while (i >= 0)
 	{
-		if (tools_is_valid_name_char(line[i]) == false)
+		if (tools_is_valid_name_char(line[i]) == false && line[i] != '/')
 			break ;
 		i--;
 	}

--- a/srcs/tools/tools_is_valid_name.c
+++ b/srcs/tools/tools_is_valid_name.c
@@ -6,7 +6,7 @@
 /*   By: jbrinksm <jbrinksm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/06/18 16:31:00 by jbrinksm       #+#    #+#                */
-/*   Updated: 2019/11/04 10:03:13 by mavan-he      ########   odam.nl         */
+/*   Updated: 2019/11/05 15:44:36 by mavan-he      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 bool	tools_is_valid_name_char(char c)
 {
-	return (ft_isalnum(c) == true || ft_strchr("*-_~!@#$%^.,[]+/?", c) != NULL);
+	return (ft_isalnum(c) == true || ft_strchr("*-_~!@#$%^.,[]+?", c) != NULL);
 }
 
 bool		tools_is_valid_name(char *str)


### PR DESCRIPTION
## Description:

alias name cannot contain a slash


**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change works
  - [x] Passes all tests: `make test`
  - [x] There is no commented out code in this PR.
  - [x] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [x] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
