### PR TITLE
Make sure exit code when command is not found is set to 127

### DIFF
--- a/srcs/jobs/jobs_launch_proc.c
+++ b/srcs/jobs/jobs_launch_proc.c
@@ -6,7 +6,7 @@
 /*   By: rkuijper <rkuijper@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/10/29 11:20:31 by rkuijper       #+#    #+#                */
-/*   Updated: 2019/11/06 10:51:56 by rkuijper      ########   odam.nl         */
+/*   Updated: 2019/11/06 17:07:09 by jbrinksm      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,6 +88,8 @@ static void	execute_proc(t_proc *proc)
 	if (proc->is_builtin == false)
 	{
 		execve(proc->binary, proc->argv, proc->env);
+		if (g_state->exit_code != 0)
+			exit(g_state->exit_code);
 		exit(1);
 	}
 	jobs_exec_fork_builtin(proc, true);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
