### PR TITLE
Fix list leaks upon bad pattern in globbing

### DIFF
--- a/srcs/globbing/glob_lexer.c
+++ b/srcs/globbing/glob_lexer.c
@@ -55,6 +55,7 @@ int				glob_lexer(t_globtoken **lst, char *word)
 		glob_lexer_state_start(scanner);
 		if (glob_add_scanned_token(lst, scanner) == FUNCT_ERROR)
 		{
+			glob_del_tokenlst(lst);
 			free(scanner);
 			return (FUNCT_ERROR);
 		}


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change works
  - [ ] Passes all tests: `make test`
  - [ ] There is no commented out code in this PR.
  - [ ] `norminette srcs libft | grep -E "^Error" | wc -l` is not higher than master. If it is, run `norminette srcs libft | grep -E "^Error" -B 1` to see errors
  - [ ] I solemny swear my code is compliant with the [README][readme-file]

[readme-file]: https://github.com/OscarMulder/codam-42sh/blob/master/README.md
